### PR TITLE
Add -[ObjectiveBASS prepareAudioSession]

### DIFF
--- a/BASS Audio Test/ObjectiveBASS.h
+++ b/BASS Audio Test/ObjectiveBASS.h
@@ -121,6 +121,8 @@ typedef NS_ENUM(NSInteger, BassStreamError) {
 - (void)next;
 - (void)stop;
 
+- (void)prepareAudioSession;
+
 - (void)playURL:(nonnull NSURL *)url
  withIdentifier:(nonnull NSUUID *)identifier;
 


### PR DESCRIPTION
Relisten needs `MPRemoteCommandCenter` and `MPNowPlayingInfoCenter` set up before the CarPlay UI will appear. Having a hook to prepare the audio session was the easiest way to do this.